### PR TITLE
fix: Set correct hovering color on navigation bar icons

### DIFF
--- a/assets/css/components/buttons.css
+++ b/assets/css/components/buttons.css
@@ -14,6 +14,10 @@
   .link-button svg {
     fill: rgb(var(--color-text-base));
   }
+
+  .link-button:hover svg {
+    fill: rgb(var(--color-text-base));
+  }
 }
 
 @layer components {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -969,6 +969,9 @@ nav button svg:hover {
 .link-button svg {
     fill: rgb(var(--color-text-base));
   }
+.link-button:hover svg {
+    fill: rgb(var(--color-text-base));
+  }
 pre:has(code) {
   border-width: 1px;
   --tw-border-opacity: 1;


### PR DESCRIPTION
## Squashed commits

* af8efac fix: Set correct hovering color on navigation bar icons

## Changelog in detail

* af8efac fix: Set correct hovering color on navigation bar icons

## All changes

- [klaudiosinani/re@`cb602c9...af8efac`](https://github.com/klaudiosinani/re/compare/cb602c9...af8efac)
